### PR TITLE
fix feature state update as a parameter

### DIFF
--- a/src/features/new-feature/new-feature.tsx
+++ b/src/features/new-feature/new-feature.tsx
@@ -46,15 +46,15 @@ const NewFeature = () => {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const refineFeature = useCallback(async () => {
+  const refineFeature = useCallback(async (name: string) => {
     setMessages([]);
-    await fetchRefinedFeatureName();
+    await fetchRefinedFeatureName(name);
     navigate(routes.refineFeature);
   }, [setMessages, fetchRefinedFeatureName, navigate]);
 
   const handleRefine = (data: NewFeatureFormValues) => {
     updateFeature({ name: data.name });
-    refineFeature();
+    refineFeature(data.name);
   };
 
   const handleFileUpload = async (

--- a/src/hooks/use-refine-feature-name.tsx
+++ b/src/hooks/use-refine-feature-name.tsx
@@ -16,11 +16,11 @@ const useRefineFeatureName = () => {
   const { feature, updateFeature, setIsLoading } = useAppStore();
   const { refinedFeature, setRefinedFeature } = useRefineFeatureStore();
 
-  const fetchRefinedFeatureName = useCallback(async () => {
+  const fetchRefinedFeatureName = useCallback(async (name: string) => {
     try {
       setIsLoading(true);
       const response = await sendRefinedFeatureName(
-        feature.name,
+        name,
         feature.textDocument
       );
       const parsedResponse = parseAidaRefinedFeatureResponse(response);


### PR DESCRIPTION
# Fix issue in feature state update

- [x] You've read the [Contributor Guide](./../CONTRIBUTING.md) and [Code of Conduct](./../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Pass feature name directly to avoid stale state access

## Description

Fixed an issue where the feature name was not properly accessible after state updates due to asynchronous nature of Zustand state changes and React re-renders.

**Problem:**
- `updateFeature({ name: data.name })` was called in `new-feature.tsx`
- Immediately after, `fetchRefinedFeatureName()` tried to access `feature.name` from the store
- The component hadn't re-rendered yet, so `feature.name` contained the old/empty value
- This caused the API call to be made with incorrect data

**Solution:**
- Modified `fetchRefinedFeatureName` in `use-refine-feature-name.tsx` to accept `name` as a parameter
- Updated `refineFeature` callback in `new-feature.tsx` to accept and pass the `name` parameter
- Changed `handleRefine` to pass `data.name` directly to `refineFeature(data.name)`
- This ensures the fresh form data is used instead of waiting for state synchronization

**Files changed:**
- `src/hooks/use-refine-feature-name.tsx`: Added `name` parameter to `fetchRefinedFeatureName`
- `src/features/new-feature/new-feature.tsx`: Updated `refineFeature` callback to accept and pass `name` parameter

Fixes #issue_number